### PR TITLE
Fix pixel argument type parsing

### DIFF
--- a/donjon_painter/painter.py
+++ b/donjon_painter/painter.py
@@ -34,6 +34,7 @@ def getArgs(showHelp=0):
     parser.add_argument(
         "-p", "--pixels",
         help="specify the size of your map tile assets (default 70)",
+        type=int,
         default=70)
     parser.add_argument(
         "-r", "--randomise",


### PR DESCRIPTION
Currently, the `--pixels` option doesn't work because `arg.pixels` is stored as a string. Setting the type in the `parser` definition fixes this and provides an appropriate error message on incorrect input.